### PR TITLE
patch: add fallback when the dialect does not have examples

### DIFF
--- a/components/card/index.js
+++ b/components/card/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { For } from 'react-extras'
+import { For, Choose } from 'react-extras'
 
 const Wrapper = styled.div`
   display: block;
@@ -43,23 +43,38 @@ const Card = ({ data }) => {
   return (
     <FlexWrap>
       <For of={data} render={item =>
-        <Wrapper key={item.slug}>
-          <hgroup>
-            <h2 className="center">{item.dialect}</h2>
-            <h3>Significado:</h3>
-          </hgroup>
-          <For of={item.meanings} render={meaning =>
-            <p key={meaning}>{meaning}</p>
-          }/>
-          <div>
-            <h3>Exemplos:</h3>
-            <For of={item.examples} render={(example, index) =>
-              <p key={example}>{example}</p>
-	          }/>
-          </div>
-        </Wrapper>
-      }/>
-
+          <Wrapper key={item.slug}>
+            <hgroup>
+              <h2 className="center">{item.dialect}</h2>
+              <h3>Significado:</h3>
+            </hgroup>
+            <For of={item.meanings} render={meaning =>
+              <p key={meaning}>{meaning}</p>
+            }/>
+            <div>
+              <h3>Exemplos:</h3>
+              <Choose>
+                <Choose.When condition={item.examples === undefined}>
+                  Nos ajude adicionando exemplos no{' '}
+                  <a
+                    href="https://github.com/mvfsillva/dialetus-service"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    Dialetus Service
+                  </a>
+                </Choose.When>
+                <Choose.When condition={Array.isArray(item.examples)}>
+                  <For
+                    of={item.examples}
+                    render={example => <p key={example}>{example}</p>}
+                  />
+                </Choose.When>
+              </Choose>
+            </div>
+          </Wrapper>
+        }
+      />
     </FlexWrap>
   )
 }


### PR DESCRIPTION
## Pre-Submission Checklist

- You have only one commit (if not, squash them into one commit).
- All new and existing tests pass the command `yarn test` and `yarn lint`.

## Description

<!--Write a description of what you changed and how to test your PR -->
When testing Dialect page. Browsing in dialects, I found this bug, when the Dialect does not have an examples.

![examples-bug](https://user-images.githubusercontent.com/12900896/53250570-6f7efc00-3699-11e9-916b-50912202ff59.gif)


## Solution

I used the `Choose` from` react-extras` to create a condition when dialect does not have examples. In this case, I thought to display the message to add new examples on Dialetus service.
